### PR TITLE
テストを通す

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,4 +1,4 @@
-module Main exposing (Model, Msg(..), init, main, update, view)
+module Main exposing (Model, Msg(..), init, main, subscriptions, update, view)
 
 import Browser exposing (Document)
 import Html exposing (button, div, text)

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -1,12 +1,18 @@
 module Example exposing (..)
 
 import Expect
-import Main exposing (add)
+import Main
 import Test exposing (..)
 
 
 suite : Test
 suite =
-    describe "add function"
-        [ test "1と1を受け取った時2になること" <| \() -> Expect.equal (add 1 1) 2
+    describe "subscription function"
+        [ test "subscriptionsがNoneを返すこと" <|
+            \() ->
+                Expect.equal
+                    (Main.subscriptions
+                        { statusText = "Ready" }
+                    )
+                    Sub.none
         ]


### PR DESCRIPTION
テンプレートから拾ってきた兼ね合いで、定義されていない関数のテストを行なっていた。
そのためCIがずっと落ちる問題があった。
この問題を解決するために、一旦いまある関数のテストを書いた。